### PR TITLE
Core,loginserver: fix bug that loginserver tell client the wrong gameserver IP in LCReconnect packet when using docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "9999:9999"
       - "9998:9998"
       - "9997:9997"
+      - "9997:9997/udp"
     volumes:
       - ../bin/:/home/darkeden/vs/bin/
       - ./conf/:/home/darkeden/vs/conf/

--- a/src/Core/CLSelectPCHandler.cpp
+++ b/src/Core/CLSelectPCHandler.cpp
@@ -339,6 +339,10 @@ void CLSelectPCHandler::execute (CLSelectPC* pPacket , Player* pPlayer)
 		//--------------------------------------------------------------------------------
 		pLoginPlayer->setPlayerStatus(LPS_AFTER_SENDING_LG_INCOMING_CONNECTION);
 
+		// by tiancaiamao: when gameserver is behind docker, it may have a docker internal IP 172.20.0.1 and a outside IP in database GameServerInfo table.
+		// The outside IP should be used.
+		pLoginPlayer->setGameServerIP(pGameServerInfo->getIP());
+
 /*
 		// 어쩔 수 없이 user name 을 사용해서 하드코딩한다. -_-;
 		g_pGameServerManager->sendPacket(pGameServerInfo->getIP() , pGameServerInfo->getUDPPort() , &lgIncomingConnection);

--- a/src/Core/GLIncomingConnectionOKHandler.cpp
+++ b/src/Core/GLIncomingConnectionOKHandler.cpp
@@ -44,9 +44,17 @@ void GLIncomingConnectionOKHandler::execute (GLIncomingConnectionOK * pPacket )
 
 		if (pLoginPlayer->getPlayerStatus() == LPS_AFTER_SENDING_LG_INCOMING_CONNECTION ) 
 		{
-	        // 클라이언트에게 게임 서버로 재접속하라고 알려준다.
+
+
+		  // Tell the client to reconnect the game server.
+		  // by tiancaiamao: when gameserver is behind docker, it may have a docker internal IP 172.20.0.1 and a outside IP in database GameServerInfo table.
+		  // The outside IP should be used.
+		  // pPacket->getHost() get the internal one.
+		  // pLoginPlayer->getGameServerIP() get the outside one.
+
 			LCReconnect lcReconnect;
-			lcReconnect.setGameServerIP(pPacket->getHost());
+			// lcReconnect.setGameServerIP(pPacket->getHost());
+			lcReconnect.setGameServerIP(pLoginPlayer->getGameServerIP());
 			lcReconnect.setGameServerPort(pPacket->getTCPPort());
 			lcReconnect.setKey(pPacket->getKey());
 

--- a/src/server/loginserver/LoginPlayer.h
+++ b/src/server/loginserver/LoginPlayer.h
@@ -147,6 +147,9 @@ public :
 	void    setBillingSession() throw (Error)   { BillingPlayerInfo::setBillingSession(this); }
 	bool    sendBillingLogin() throw (Error);
 
+public :
+  void setGameServerIP(const string& ip) { m_gameServerIP = ip; }
+  const string& getGameServerIP() { return m_gameServerIP; }
 
 private :
 	
@@ -187,6 +190,9 @@ private :
 
 	// 웹 로그인 모드
 	bool			m_bWebLogin;
+
+  // m_gameServerIP is set in CLSelectPCHandler.
+  string m_gameServerIP;
 };
 
 #endif


### PR DESCRIPTION
Fix https://github.com/opendarkeden/server/issues/38

The bug happen when server is deployed using docker.
The loginserver tell the client to reconnect gameserver with a internal IP (docker IP like `172.xxx`)


In the docker environment, the gameserver has two IPs.
One is the internal docker IP, the other one is the real machine's IP.

The loginserver send a `LCReconnect` packet to the client to ask it to reconnect.
The real IP should be used, instead of the docker internal IP.

LoginPlayer is changed to save that IP in the `m_gameServerIP` field.