### PR TITLE
added: `apt install psmisc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt update && apt install -y \
     xutils-dev \
     psmisc \
     && rm -rf /var/lib/apt/lists/*
+	
+RUN apt install -y psmisc
 
 RUN mkdir /home/darkeden
 RUN mkdir /home/darkeden/vs


### PR DESCRIPTION
added: `apt install psmisc`

reason: command `killall` is not found, thus `start.sh` and `stop.sh` does not kill processes.

structure: I have purposely added the package in a new line, to avoid Docker caching again.