### PR TITLE
Core/ModifyInfo: fix ModifyInfo packet size

### DIFF
--- a/src/Core/ModifyInfo.h
+++ b/src/Core/ModifyInfo.h
@@ -222,8 +222,8 @@ public:
 public:
     void read (SocketInputStream & iStream) ;
     void write (SocketOutputStream & oStream) const ;
-	PacketSize_t getPacketSize () const  { return szBYTE*2 + m_ShortCount*(szBYTE+szshort) + m_LongCount*(szBYTE+szlong); }
-	static PacketSize_t getPacketMaxSize()  { return szBYTE*2 + 255*(szBYTE+szshort+szBYTE+szlong); }
+	PacketSize_t getPacketSize () const  { return szBYTE*2 + m_ShortCount*(szBYTE+szshort) + m_LongCount*(szBYTE+szDWORD); }
+	static PacketSize_t getPacketMaxSize()  { return szBYTE*2 + 255*(szBYTE+szshort+szBYTE+szDWORD); }
 	string toString () const ;
 
 public:


### PR DESCRIPTION
Fix #50 

The data is DWORD, so its size should be szDWORD.
The old code use szlong, and works fine in 32bit OS coincidently, because in 32bit OS szDWORD == szlong...

After this fix, there should be no error log like "writePacket WARN: diff size = 44 real size = 60before:80 after:124" related to ModifyInfo, and the Slayer fast recovery skill is fixed.