### PR TITLE
database: fix SkillBalance table to make skills SkyFire/CutStorm/DeadlyClaw/VoodooRing work

### DIFF
--- a/src/server/gameserver/skill/SkillHandler.h
+++ b/src/server/gameserver/skill/SkillHandler.h
@@ -63,8 +63,8 @@ public:
 public:
 	int             SkillLevel;
 	int             DomainLevel;
-	int				STR;
-	int				DEX;
+	int		STR;
+	int		DEX;
 	int             INTE;
 	int             TargetType;
 	int             Range;


### PR DESCRIPTION
The server has implemented the 171 skills like SkyFire ...
According to https://github.com/opendarkeden/client/issues/24#issuecomment-923939931
There are some missing data of the `SkillBalance` table.

I try to fill them to make those skills work.

```
(386, 'Sky Fire', 'Sky Fire', 150, 0,0,4,4,0,0,10,8,8,3,1200000,1,0,1,0,0,0,1,0,0,'(359)','',-1,0,0)
(387 ,'Cut Storm",'Cut Storm',150,30,80,4,4,0,0,8,3,3,2,56000,32,0,0,0,0,0,1,0,0,'','',-1,0,0)
(391 ,'Deadly Claw','Deadly Claw',150,10,60,5,20,0,0,15,2,2,2,0,0,0,6,0,1,0,1,0,0,'','',-1,0,0)
(392 ,'Voodoo Ring','Voodoo Ring',150,0,0,120,120,0,0,50,0,0,6,0,1,0,6,0,0,1,0,0,0,'','',-1,0,0)
```