### PR TITLE
Core: fix summon Pet

### DIFF
--- a/src/Core/CGUseItemFromInventoryHandler.cpp
+++ b/src/Core/CGUseItemFromInventoryHandler.cpp
@@ -2433,11 +2433,11 @@ void CGUseItemFromInventoryHandler::executePetItem(CGUseItemFromInventory* pPack
 		if ( pPetInfo == NULL || pPetInfo->getPetItem() != pPetItem )
 		{
 			pPC->setPetInfo( pTargetPetInfo );
-			//cout << pPetItem->getObjectID() << " ¾ÆÀÌÅÛÀÇ ÆêÀ» ºÒ·¶½À´Ï´Ù." << endl;
+			cout << pPetItem->getObjectID() << " call the pet item." << endl;
 		}
 		else
 		{
-			//cout << "ÆêÀ» Áö¿ü½À´Ï´Ù." << endl;
+			cout << "recall the pet" << endl;
 			pPC->setPetInfo( NULL );
 		}
 

--- a/src/Core/GCPetInfo.cpp
+++ b/src/Core/GCPetInfo.cpp
@@ -10,10 +10,6 @@
 #include "GuildWarInfo.h"
 #include "Assert1.h"
 
-#ifdef __GAME_SERVER__
-#include "PetItem.h"
-#endif
-
 //////////////////////////////////////////////////////////////////////////////
 // constructor
 //////////////////////////////////////////////////////////////////////////////
@@ -105,21 +101,20 @@ string GCPetInfo::toString () const
 		
 	StringStream msg;
 	
-	msg << "GCPetInfo(" ;
+	msg << "GCPetInfo("
+	    << "ObjectID:" << m_ObjectID
+	    << "PetInfo:";
+
+	if (m_pPetInfo == NULL) {
+	  msg << "NULL";
+	} else {
+	  msg << m_pPetInfo->toString();
+	}
+	  
+	msg << "IsSummonInfo:" << m_IsSummonInfo;
 	msg << ")";
 
 	return msg.toString();
 		
 	__END_CATCH
 }
-
-ObjectID_t PetInfo::getItemObjectID() const
-{
-#ifdef __GAME_SERVER__
-	if (m_pPetItem == NULL ) return 0;
-		return m_pPetItem->getObjectID();
-#else
-	return 0;
-#endif
-}
-

--- a/src/Core/PetInfo.cpp
+++ b/src/Core/PetInfo.cpp
@@ -1,4 +1,5 @@
 #include "PetInfo.h"
+#include "PetItem.h"
 
 PetInfo::PetInfo()
 {
@@ -101,7 +102,14 @@ string PetInfo::toString() const
 		<< ", PetAttr : " << (int)m_PetAttr
 		<< ", PetOption : " << (int)m_PetOption
 		<< ", PetFoodType : " << (int)m_PetFoodType
+	        << ", ItemObjectID : " << getItemObjectID()
 		<< ")";
 
 	return msg.toString();
+}
+
+ObjectID_t PetInfo::getItemObjectID() const
+{
+	if (m_pPetItem == NULL ) return 0;
+	return m_pPetItem->getObjectID();
 }


### PR DESCRIPTION
Fix #36 

The PetItemObject ID is not correct, the item Object ID is set to 0
and the client will not display the pet