### PR TITLE
src/server/gameserver/skill: fix server panic when casting SimpleTileCure skill

### DIFF
--- a/src/Core/GCAddBat.h
+++ b/src/Core/GCAddBat.h
@@ -132,7 +132,7 @@ public:
 			//+ szSpriteType 
 			//+ szColor + szColor
 			+ szCoord + szCoord + szDir
-			+ szHP
+			+ szHP*2
 			+ szGuildID
 			+ szColor
 			;

--- a/src/server/gameserver/skill/SimpleTileCureSkill.cpp
+++ b/src/server/gameserver/skill/SimpleTileCureSkill.cpp
@@ -808,7 +808,7 @@ void SimpleTileCureSkill::execute(Slayer* pSlayer, ZoneCoord_t X, ZoneCoord_t Y,
 
 				}
 
-				cList = pZone->broadcastSkillPacket(myX, myY, X, Y, &_GCSkillToTileOK5, cList);
+				pZone->broadcastSkillPacket(myX, myY, X, Y, &_GCSkillToTileOK5, cList);
 
 				pZone->broadcastPacket(myX, myY,  &_GCSkillToTileOK3 , cList);
 				pZone->broadcastPacket(X, Y,  &_GCSkillToTileOK4 , cList);


### PR DESCRIPTION
Fix this panic:

```
(gdb) bt
#0  0x000055cc1daaa504 in Creature::isSlayer (this=0x7f9b00000000) at Creature.h:103
#1  0x000055cc1daaa5fa in Creature::isPC (this=0x7f9b00000000) at Creature.h:108
#2  0x000055cc2366699c in SimpleTileCureSkill::execute (this=0x55cc279bc7c0 <g_SimpleTileCureSkill>, pSlayer=0x55cc33c95010, X=69, Y=192, pSkillSlot=0x55cc33c9d960, param=..., result=..., CEffectID=0) at SimpleTileCureSkill.cpp:778
#3  0x000055cc21524752 in CureSeriousWounds::execute (this=0x55cc26d85300 <g_CureSeriousWounds>, pSlayer=0x55cc33c95010, X=69, Y=192, pSkillSlot=0x55cc33c9d960, CEffectID=216) at CureSeriousWounds.cpp:100
#4  0x000055cc20a81259 in CGSkillToTileHandler::execute (pPacket=0x7f9bbc056200, pPlayer=0x55cc33bf0250) at CGSkillToTileHandler.cpp:137
#5  0x000055cc201f870d in CGSkillToTile::execute (this=0x7f9bbc056200, pPlayer=0x55cc33bf0250) at CGSkillToTile.cpp:91
#6  0x000055cc1dba5631 in GamePlayer::processCommand (this=0x55cc33bf0250, Option=true) at GamePlayer.cpp:528
#7  0x000055cc1dd46319 in ZonePlayerManager::processCommands (this=0x55cc2ed2b8a0) at ZonePlayerManager.cpp:617
#8  0x000055cc1dd0d73f in ZoneGroup::processPlayers (this=0x55cc2eaf31b0) at ZoneGroup.cpp:157
#9  0x000055cc1dd601ee in ZoneGroupThread::run (this=0x55cc33bf80d0) at ZoneGroupThread.cpp:137
#10 0x000055cc1fc7eb31 in start_routine (derivedThread=0x55cc33bf80d0) at Thread.cpp:225
#11 0x00007f9bcfa71609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#12 0x00007f9bceb6e163 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

See also https://github.com/opendarkeden/server/pull/64

The panic is cause by this pattern, the `zList` is changed during visiting: 

```
for(list<Creature*>::const_iterator itr = cList.begin(); itr != cList.end(); itr++)
{
	Creature* pTargetCreature = *itr;
	Assert(pTargetCreature != NULL);
	...

	cList = pZone->broadcastSkillPacket(myX, myY, X, Y, &_GCSkillToTileOK5, cList)

```
