### PR TITLE
config,docker: update docker guide and publish the binary instead of the src

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y \
+    gcc \
+    build-essential \
+    libxerces-c-dev \
+    libmysqlclient-dev \
+    xutils-dev \
+    psmisc
+	
+RUN mkdir /home/darkeden
+RUN mkdir /home/darkeden/vs
+RUN mkdir /home/darkeden/vs/src
+
+COPY libs /home/darkeden/libs/
+
+ENV CPLUS_INCLUDE_PATH=/home/darkeden/libs/lua-4.0.1/include:$CPLUS_INCLUDE_PATH
+ENV LIBRARY_PATH=/home/darkeden/libs/lua-4.0.1/lib/:$LIBRARY_PATH
+
+WORKDIR /home/darkeden/vs/src

--- a/Dockerfile.pub
+++ b/Dockerfile.pub
@@ -3,23 +3,21 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update && apt install -y \
-    gcc \
-    build-essential \
     libxerces-c-dev \
     libmysqlclient-dev \
-    xutils-dev \
     psmisc \
     && rm -rf /var/lib/apt/lists/*
-	
-RUN apt install -y psmisc
 
 RUN mkdir /home/darkeden
 RUN mkdir /home/darkeden/vs
 RUN mkdir /home/darkeden/vs/src
 
 COPY libs /home/darkeden/libs/
-
 ENV CPLUS_INCLUDE_PATH=/home/darkeden/libs/lua-4.0.1/include:$CPLUS_INCLUDE_PATH
 ENV LIBRARY_PATH=/home/darkeden/libs/lua-4.0.1/lib/:$LIBRARY_PATH
 
-WORKDIR /home/darkeden/vs/src
+COPY bin /home/darkeden/vs/bin/
+COPY data /home/darkeden/vs/data/
+COPY docker/conf /home/darkeden/vs/conf/
+
+WORKDIR /home/darkeden/vs/bin

--- a/conf/gameserver.conf
+++ b/conf/gameserver.conf
@@ -12,12 +12,12 @@
 User : excel96
 HomePath : /home/genius/project/opendarkeden/server
 TCPPort : 9998
-MonitorClientIP1 : 192.168.0.14
+MonitorClientIP1 : 192.168.0.16
 MonitorClient1UDPORT : 9876
-MonitorClientIP2 : 192.168.0.14
+MonitorClientIP2 : 192.168.0.16
 MonitorClient2UDPORT : 9876
 
-LoginServerIP: 192.168.0.14
+LoginServerIP: 192.168.0.16
 LoginServerUDPPort : 9996
 LoginServerBaseUDPPort : 9800
 LoginServerUDPPortNum : 1
@@ -26,7 +26,7 @@ GameServerUDPPort : 9997
 #--------------------------------------------------
 # Shared - Game Server Section
 #--------------------------------------------------
-SharedServerIP : 192.168.0.14
+SharedServerIP : 192.168.0.16
 SharedServerPort : 9977
 
 #--------------------------------------------------
@@ -48,13 +48,13 @@ BaseRealTime : 2000-5-1
 #--------------------------------------------------
 # DB connection
 #--------------------------------------------------
-DB_HOST : 192.168.0.14
+DB_HOST : 192.168.0.16
 DB_PORT : 3306
 DB_DB : DARKEDEN
 DB_USER : elcastle
 DB_PASSWORD : elca110
 
-UI_DB_HOST : 192.168.0.14
+UI_DB_HOST : 192.168.0.16
 UI_DB_PORT : 3306
 UI_DB_DB : USERINFO
 UI_DB_USER : elcastle

--- a/conf/loginserver.conf
+++ b/conf/loginserver.conf
@@ -20,7 +20,7 @@ GameServerUDPPort : 9997
 #--------------------------------------------------
 # BillingSystem Server
 #--------------------------------------------------
-BillingServerIP : 192.168.0.14
+BillingServerIP : 192.168.0.16
 BillingServerPort : 3001
 
 # 
@@ -36,19 +36,19 @@ ServerInfoReloadTime : 1
 #--------------------------------------------------
 # DB connection
 #--------------------------------------------------
-DB_HOST : 192.168.0.14
+DB_HOST : 192.168.0.16
 DB_PORT : 3306
 DB_DB : DARKEDEN
 DB_USER : elcastle
 DB_PASSWORD : elca110
 
-UI_DB_HOST : 192.168.0.14
+UI_DB_HOST : 192.168.0.16
 DB_PORT : 3306
 UI_DB_DB : USERINFO
 UI_DB_USER : elcastle
 UI_DB_PASSWORD : elca110
 
-DIST_DB_HOST : 192.168.0.14
+DIST_DB_HOST : 192.168.0.16
 DB_PORT : 3306
 DIST_DB_DB : DARKEDEN
 DIST_DB_USER : elcastle
@@ -59,7 +59,7 @@ DIST_DB_PASSWORD : elca110
 #--------------------------------------------------------------------------------
 
 # 
-LogServerIP : 192.168.0.14
+LogServerIP : 192.168.0.16
 
 #
 LogServerPort : 5000

--- a/conf/sharedserver.conf
+++ b/conf/sharedserver.conf
@@ -20,19 +20,19 @@ TCPPort : 9977
 #--------------------------------------------------
 # DB connection
 #--------------------------------------------------
-DB_HOST : 192.168.0.14
+DB_HOST : 192.168.0.16
 DB_PORT : 3306
 DB_DB : DARKEDEN
 DB_USER : elcastle
 DB_PASSWORD : elca110
 
-UI_DB_HOST : 192.168.0.14
+UI_DB_HOST : 192.168.0.16
 DB_PORT : 3306
 UI_DB_DB : USERINFO
 UI_DB_USER : elcastle
 UI_DB_PASSWORD : elca110
 
-DIST_DB_HOST : 192.168.0.14
+DIST_DB_HOST : 192.168.0.16
 DB_PORT : 3306
 DIST_DB_DB : DARKEDEN
 DIST_DB_USER : elcastle
@@ -43,7 +43,7 @@ DIST_DB_PASSWORD : elca110
 #--------------------------------------------------------------------------------
 
 # <E8><82><BA><E5><BC><8A> <E8><BE><91><E6><BB><9A> <E6><9E><97><E5><AE><B6>
-LogServerIP : 192.168.0.14
+LogServerIP : 192.168.0.16
 
 # <E8><82><BA><E5><BC><8A> <E8><BE><91><E6><BB><9A> <E5><99><A8><E9><A3><98>
 LogServerPort : 5001

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - odk-network
 
   odk-server:
-    image: darkeden
+    image: darkeden:latest
     build:
       context: ..
       dockerfile: Dockerfile
@@ -24,10 +24,10 @@ services:
       - "9998:9998"
       - "9997:9997"
       - "9997:9997/udp"
-    volumes:
-      - ../bin/:/home/darkeden/vs/bin/
-      - ./conf/:/home/darkeden/vs/conf/
-      - ../data/:/home/darkeden/vs/data/
+    # volumes:
+    #   - ../bin/:/home/darkeden/vs/bin/
+    #   - ./conf/:/home/darkeden/vs/conf/
+    #   - ../data/:/home/darkeden/vs/data/
     networks:
       - odk-network
 

--- a/docker_install.md
+++ b/docker_install.md
@@ -1,23 +1,23 @@
-## Install using Docker
+# Install using Docker
 
-### Build the server binary files
+## Build the server binary files
 
 First, build the docker image:
 
 ```bash
-docker build -t darkeden .
+docker build -t darkeden:dev . -f Dockerfile.dev
 ```
 
 Second, run the container
 
 ```bash
-docker run -v `pwd`:/home/darkeden/vs/ -it darkeden /bin/bash
+docker run -v `pwd`:/home/darkeden/vs/ -it darkeden:dev /bin/bash
 ```
 
 On Windows `pwd` should be changed to %cd%
 
 ```
-docker run -v %cd%/:/home/darkeden/vs/ -it darkeden /bin/bash
+docker run -v %cd%/:/home/darkeden/vs/ -it darkeden:dev /bin/bash
 ```
 
 Third, build the darkeden server binary files
@@ -28,6 +28,39 @@ make
 
 and you can add `-j 8` to the `make` command.
 
+When the build process finish, you can exit docker, and you can see loginserver/sharedserver/gameserver in the bin/ directory.
+
+
+## Run the binary (development mode)
+
+
+TODO
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## Standalone version
+
+**NOTE:** standalone version only support deploying server and client on the same machine.
+
+If you want to run server on one machine, and client on the other, you need to modify mysql `DARKEDEN.GameServerInfo` table and restart server.
+
+### Packet the binary/config/data files into docker image
+
+```sh
+docker build . -t darkeden:latest -f Dockerfile.pub
+```
 
 ### Run using docker-compose
 
@@ -55,4 +88,33 @@ Stop all:
 ```sh
 ./stop.sh
 docker-compose down
+```
+
+
+
+
+
+
+
+
+
+
+## Howto
+
+### Login to the MySQL
+
+```sh
+docker exec -it docker_odk-mysql_1 mysql -u elcastle -pelca110
+```
+
+```SQL
+use DARKEDEN;
+update GameServerInfo set IP = '192.168.0.16';
+```
+
+### Publish the docker image (memo for me)
+
+```sh
+docker tag c0bdad60a1a7(TAG) tiancaiamao/darkeden:latest
+docker push tiancaiamao/darkeden:latest
 ```


### PR DESCRIPTION
seperate Dockerfile to Dockerfile.dev and Dockerfile.pub

Publish the binary instead of the src, the user would be easier to get a standalone version.
For developers, they can still follow the guide and use develop mode.