### PR TITLE
Core: fix IP_t size to make party join work correctly

### DIFF
--- a/src/Core/GCPartyJoined.cpp
+++ b/src/Core/GCPartyJoined.cpp
@@ -190,25 +190,13 @@ string GCPartyJoined::toString () const
 	for (; itr != m_MemberInfoList.end(); itr++)
 	{
 		PARTY_MEMBER_INFO* pInfo = (*itr);
-		msg << "("
-			<< pInfo->name
-			<< "),";
-	}
-
-	/*
-	list<PARTY_MEMBER_INFO*>::const_iterator itr = m_MemberInfoList.begin();
-	for (; itr != m_MemberInfoList.end(); itr++)
-	{
-		PARTY_MEMBER_INFO* pInfo = (*itr);
 		msg << "Element("
 			<< "Name:"       << pInfo->name
 			<< ",Sex:"       << (int)pInfo->sex
 			<< ",HairStyle:" << (int)pInfo->hair_style
-			<< ",MainColor:" << (int)pInfo->main_color
-			<< ",SubColor:"  << (int)pInfo->sub_color 
+			<< ",IP:"  << (int)pInfo->ip
 			<< "),";
 	}
-	*/
 
 	msg << ")";
 	return msg.toString();

--- a/src/Core/SocketOutputStream.cpp
+++ b/src/Core/SocketOutputStream.cpp
@@ -145,7 +145,7 @@ void SocketOutputStream::writePacket ( const Packet * pPacket )
 	m_Sequence++;
 	
 	// Now, the packet body is used as the output buffer.
-	cout<<"Send:" << packetID << " " <<pPacket->toString() <<endl;
+	cout<<"Send:" << packetID << "[" << packetSize << "," << (m_Sequence-1) << "]" << " " <<pPacket->toString() <<endl;
 	Assert(packetID != 0);
 
 	uint l1 = length();

--- a/src/Core/types/SystemTypes.h
+++ b/src/Core/types/SystemTypes.h
@@ -110,7 +110,7 @@ enum WorldStatus
 	WORLD_CLOSE	
 };
 
-typedef unsigned long IP_t;
+typedef unsigned int IP_t;
 const uint szIP = sizeof(IP_t);
 
 typedef BYTE WorldID_t;


### PR DESCRIPTION
close #75

```
typedef unsigned long IP_t;
```

On linux x64, sizeof `unsigned long` is 8
While on window, the client part, sizeof `unsigned long` is 4
This mismatch make the packet parsing error 

Now I change the server part IP_t definition to `unsigned int` so it works well with the client.