### PR TITLE
skill: fix FireMeteor and SacredStamp skill

### DIFF
--- a/src/server/gameserver/skill/FireMeteor.h
+++ b/src/server/gameserver/skill/FireMeteor.h
@@ -24,6 +24,7 @@ public:
 	SkillType_t getSkillType() const throw() { return SKILL_Fire_Meteor; }
 
 	void execute(Ousters* pOusters, ObjectID_t ObjectID,  OustersSkillSlot* pOustersSkillSlot, CEffectID_t CEffectID) ;
+	void execute(Ousters* pOusters, ZoneCoord_t X, ZoneCoord_t Y, OustersSkillSlot* pSkillSlot, CEffectID_t CEffectID) ;
 
 	void computeOutput(const SkillInput& input, SkillOutput& output);
 };

--- a/src/server/gameserver/skill/SacredStamp.h
+++ b/src/server/gameserver/skill/SacredStamp.h
@@ -25,6 +25,7 @@ public:
 	SkillType_t getSkillType() const throw() { return SKILL_Sacred_Stamp; }
 
 	void execute(Slayer* pSlayer, ObjectID_t ObjectID,  SkillSlot* pSkillSlot, CEffectID_t CEffectID) ;
+	void execute(Slayer* pSlayer, ZoneCoord_t X, ZoneCoord_t Y, SkillSlot* pSkillSlot, CEffectID_t CEffectID) ;
 
 	void computeOutput(const SkillInput& input, SkillOutput& output);
 };


### PR DESCRIPTION
close https://github.com/opendarkeden/server/issues/96

They should be SimpleTileMissileSkill (AOE)

Apparently the Ousters skill FireMeteor is modified from MagnumSpear ... which is incorrect.

SacredStamp is similiar to BombingStar, with the damage formula slightly differs.