### PR TITLE
skill: change ReactiveArmor effect

### DIFF
--- a/src/server/gameserver/InitAllStat.cpp
+++ b/src/server/gameserver/InitAllStat.cpp
@@ -4216,17 +4216,6 @@ void Ousters::initAllStat(int numPartyMember)
 		m_Resist[MAGIC_DOMAIN_BLOOD]     += ResistBonus;
 	}
 
-	if ( isFlag( Effect::EFFECT_CLASS_REACTIVE_ARMOR ) )
-	{
-		EffectReactiveArmor* pEffect = dynamic_cast<EffectReactiveArmor*>(findEffect(Effect::EFFECT_CLASS_REACTIVE_ARMOR));
-
-		if ( pEffect != NULL )
-		{
-			int bonus = pEffect->getBonus();
-			m_Protection[ATTR_CURRENT] += bonus;
-			m_Defense[ATTR_CURRENT] += bonus;
-		}
-	}
 	if (isFlag(Effect::EFFECT_CLASS_INTIMATE_GRAIL))
 	{
 		EffectIntimateGrail* pIntimateGrail = dynamic_cast<EffectIntimateGrail*>(findEffect(Effect::EFFECT_CLASS_INTIMATE_GRAIL));
@@ -4531,6 +4520,29 @@ void Ousters::initAllStat(int numPartyMember)
 		{
 			int bonus = pEffect->getBonus();
 			m_ToHit[ATTR_CURRENT] += getPercentValue( m_ToHit[ATTR_CURRENT], bonus );
+		}
+	}
+	if ( isFlag( Effect::EFFECT_CLASS_REACTIVE_ARMOR ) )
+	{
+		EffectReactiveArmor* pEffect = dynamic_cast<EffectReactiveArmor*>(findEffect(Effect::EFFECT_CLASS_REACTIVE_ARMOR));
+
+		if ( pEffect != NULL )
+		{
+		  bool unaffect = false;
+		  if (  getSkill( SKILL_REACTIVE_ARMOR ) != NULL ) {
+		    SkillInfo* pSkillInfo = g_pSkillInfoManager->getSkillInfo( SKILL_REACTIVE_ARMOR );
+		    if ( pSkillInfo != NULL && !satisfySkillRequire( pSkillInfo ) ) {
+		      unaffect = true;
+		    }
+		  }
+
+		  if ( unaffect ) {
+		        pEffect->setDeadline(0);
+		  } else {
+			int bonus = pEffect->getBonus();
+			m_Protection[ATTR_CURRENT] += bonus;
+			m_Defense[ATTR_CURRENT] += bonus;
+		  }
 		}
 	}
 

--- a/src/server/gameserver/skill/ReactiveArmor.cpp
+++ b/src/server/gameserver/skill/ReactiveArmor.cpp
@@ -196,18 +196,21 @@ void ReactiveArmor::execute(Ousters* pOusters, ObjectID_t TargetObjectID,  Ouste
 		{
 			decreaseMana(pOusters, RequiredMP, _GCSkillToObjectOK1);
 
-        	bool bCanSeeCaster = canSee(pTargetCreature, pOusters);
+			bool bCanSeeCaster = canSee(pTargetCreature, pOusters);
+			uint damageReduce = 0;
 
 			OustersSkillSlot* pMastery = pOusters->hasSkill( SKILL_REACTIVE_ARMOR_MASTERY );
 			if ( pMastery != NULL )
 			{
 				output.Damage += 5 + (pMastery->getExpLevel()*2/5);
+				damageReduce = 20 + pMastery->getExpLevel();
 			}
 
 			// 이펙트 오브젝트를 생성해 붙인다.
 			EffectReactiveArmor* pEffect = new EffectReactiveArmor(pTargetCreature);
 			pEffect->setDeadline(output.Duration);
 			pEffect->setBonus(output.Damage);
+			pEffect->setDamageReduce(damageReduce);
 			pTargetCreature->addEffect(pEffect);
 			pTargetCreature->setFlag(Effect::EFFECT_CLASS_REACTIVE_ARMOR);
 


### PR DESCRIPTION
close https://github.com/opendarkeden/server/issues/125

1. if the earth stone is less than required, the effect would gone
2. damage reduce not works on all instead of self only

This change encourage cooperation and not weaken the ousters race See https://github.com/opendarkeden/server/issues/125